### PR TITLE
Improved equalTime failure message

### DIFF
--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -59,7 +59,9 @@
     return this.assert(
       chai.datetime.equalTime(expected, actual),
       'expected ' + this._obj + ' to equal ' + expected,
-      'expected ' + this._obj + ' to not equal ' + expected
+      'expected ' + this._obj + ' to not equal ' + expected,
+      expected.toString(),
+      actual.toString()
     );
   });
 


### PR DESCRIPTION
Added expected and actual values to the assert() call so that the correct values show up in the output from a failure if diff is shown.

Before change:
AssertionError: expected Thu Jul 31 2014 00:00:00 GMT-0400 (EDT) to equal Wed Jul 30 2014 23:59:59 GMT-0400 (EDT)
Expected :undefined
Actual   :{}

After change:
AssertionError: expected Thu Jul 31 2014 00:00:00 GMT-0400 (EDT) to equal Wed Jul 30 2014 23:59:59 GMT-0400 (EDT)
Expected :"Wed Jul 30 2014 23:59:59 GMT-0400 (EDT)"
Actual   :"Thu Jul 31 2014 00:00:00 GMT-0400 (EDT)"
