### PR TITLE
Timezone insensitive date comparisons

### DIFF
--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -38,7 +38,7 @@
   };
 
   var dateWithoutTime = function(date) {
-    return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
   }
 
   chai.datetime.beforeDate = function(actual, expected) {

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,12 @@
           it('returns false', function() {
             chai.datetime.afterDate(this.actual, this.expected).should.be.eq(false)
           });
+
+          it('should not be affected by time zones', function() {
+            var midnight = new Date(2014, 0, 1, 0);
+            var endOfDay = new Date(2014, 0, 1, 23);
+            chai.datetime.afterDate(endOfDay, midnight).should.be.false;
+          });
         });
 
         describe('when given the actual is before the expected', function() {
@@ -106,6 +112,12 @@
 
           it('returns false', function() {
             chai.datetime.beforeDate(this.actual, this.expected).should.be.eq(false)
+          });
+
+          it('should not be affected by time zones', function() {
+            var midnight = new Date(2014, 0, 1, 0);
+            var endOfDay = new Date(2014, 0, 1, 23);
+            chai.datetime.beforeDate(midnight, endOfDay).should.be.false;
           });
         });
 


### PR DESCRIPTION
Converting dates to UTC causes date will make date comparisons depend on your timezone. Adding tests that should cover arbitrary time zones (although the test will only test the local time zone).

After this patch, all comparisons are working in PST where they were failing before.
