### PR TITLE
Allowing lazy developers to equal date as a string.

### DIFF
--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -21,6 +21,10 @@
 }(function(chai, utils){
   chai.datetime = chai.datetime || {};
 
+  function asDate(date) {
+    return (date instanceof Date) ? date : new Date(date);
+  }
+
   function padNumber(num, length) {
     var ret = '' + num;
     var i = ret.length;
@@ -48,7 +52,7 @@
   }
 
   chai.datetime.formatDate = function(date) {
-    return date.toDateString();
+    return asDate(date).toDateString();
   };
 
   chai.datetime.formatTime = function(time) {
@@ -65,7 +69,7 @@
   };
 
   chai.datetime.equalDate = function(actual, expected) {
-    return actual.toDateString() === expected.toDateString();
+    return actual.toDateString() === asDate(expected).toDateString();
   };
 
   var dateWithoutTime = function(date) {

--- a/test/test.js
+++ b/test/test.js
@@ -246,6 +246,48 @@
           });
         });
 
+        describe('when a lazy developer provides a non-date to match against', function() {
+          var theSameAsAString = '2013-05-30';
+          var theSameAsMillisecondsSinceEpoch = 1369872000000;
+
+          it('date as string passes', function() {
+            this.subject.should.be.equalDate(theSameAsAString);
+          });
+
+          it('date as epoch time passes', function() {
+            this.subject.should.be.equalDate(theSameAsMillisecondsSinceEpoch);
+          });
+
+          describe('when negated', function() {
+            it('date as string fails', function() {
+              var test = this;
+
+              (function() {
+                test.subject.should.not.be.equalDate(theSameAsAString);
+              }).should.fail(
+                'expected Thu May 30 2013 to not equal Thu May 30 2013'
+              );
+            });
+            it('date as epoch time fails', function() {
+              var test = this;
+              (function() {
+                test.subject.should.not.be.equalDate(theSameAsMillisecondsSinceEpoch);
+              }).should.fail(
+                'expected Thu May 30 2013 to not equal Thu May 30 2013'
+              );
+            });
+          });
+
+          describe('error handling', function() {
+            it('should complain if unusable date string provided', function() {
+              var test = this;
+              (function() {
+                test.subject.should.be.equalDate('THIS IS NOT A DATE');
+              }).should.fail('expected Thu May 30 2013 to equal Invalid Date');
+            });
+          });
+
+        });
       });
     });
 


### PR DESCRIPTION
For details see https://github.com/gaslight/chai-datetime/issues/19
