### PR TITLE
Adding aroundTime assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ portion of the Date object.
 * equalTime
 * beforeTime
 * afterTime
+* aroundTime
 * equalDate
 * beforeDate
 * afterDate
+
+`aroundTime` is the only assertion that takes two arguments. Besides a date, it also takes `delta` - time difference in milliseconds.
 
 All assertions are defined for both the BDD and TDD syntaxes.
 

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -88,6 +88,11 @@
     return actual.getTime() > expected.getTime();
   };
 
+  chai.datetime.aroundTime = function(actual, expected, delta) {
+    return (actual.getTime() >= expected.getTime() - delta) &&
+           (actual.getTime() <= expected.getTime() + delta);
+  };
+
   chai.Assertion.addChainableMethod('equalTime', function(expected) {
     var actual = this._obj;
 
@@ -151,6 +156,17 @@
     );
   });
 
+  chai.Assertion.addChainableMethod('aroundTime', function(expected, delta) {
+    var actual = this._obj;
+
+    this.assert(
+      chai.datetime.aroundTime(actual, expected, delta),
+      'expected ' + chai.datetime.formatTime(actual) + ' to be around ' + chai.datetime.formatTime(expected) + ' +/- ' + delta + ' ms',
+      'expected ' + chai.datetime.formatTime(actual) + ' not to be around ' + chai.datetime.formatTime(expected) + ' +/- ' + delta + ' ms'
+    );
+  });
+
+
   // Asserts
   var assert = chai.assert;
 
@@ -202,4 +218,11 @@
     new chai.Assertion(val, msg).to.not.be.afterTime(exp);
   };
 
+  assert.aroundTime = function(val, exp, delta, msg) {
+    new chai.Assertion(val, msg).to.be.aroundTime(exp, delta);
+  };
+
+  assert.notAroundTime = function(val, exp, delta, msg) {
+    new chai.Assertion(val, msg).to.not.be.aroundTime(exp, delta);
+  };
 }));

--- a/test/test.js
+++ b/test/test.js
@@ -487,6 +487,150 @@
       });
     });
 
+    describe('aroundTime', function() {
+      describe('when first time is before second', function() {
+        describe('and delta is exact difference between two times', function() {
+          beforeEach(function() {
+            this.d1 = new Date(2013, 4, 30, 16, 5, 0);
+            this.d2 = new Date(2013, 4, 30, 16, 5, 1);
+          });
+
+          it('passes', function() {
+            this.d1.should.be.aroundTime(this.d2, 1000);
+          });
+
+          describe('when negated', function() {
+            it('fails', function() {
+              var test = this;
+
+              (function() {
+                test.d1.should.not.be.aroundTime(test.d2, 1000)
+              }).should.fail(
+                'expected ' + chai.datetime.formatTime(this.d1) + ' not to be around ' + chai.datetime.formatTime(this.d2) + ' +/- 1000 ms'
+              );
+            });
+          });
+        });
+
+        describe('and delta is bigger than two times difference', function() {
+          beforeEach(function() {
+            this.d1 = new Date(2013, 4, 30, 16, 5, 0);
+            this.d2 = new Date(2013, 4, 30, 16, 5, 1);
+          });
+
+          it('passes', function() {
+            this.d1.should.be.aroundTime(this.d2, 2000);
+          });
+
+          describe('when negated', function() {
+            it('fails', function() {
+              var test = this;
+
+              (function() {
+                test.d1.should.not.be.aroundTime(test.d2, 2000)
+              }).should.fail(
+                'expected ' + chai.datetime.formatTime(this.d1) + ' not to be around ' + chai.datetime.formatTime(this.d2) + ' +/- 2000 ms'
+              );
+            });
+          });
+        });
+
+        describe('and delta is smaller than two times difference', function() {
+          beforeEach(function() {
+            this.d1 = new Date(2013, 4, 30, 16, 5, 0);
+            this.d2 = new Date(2013, 4, 30, 16, 5, 1);
+          });
+
+          it('fails', function() {
+            var test = this;
+
+            (function() {
+              test.d1.should.be.aroundTime(test.d2, 500)
+            }).should.fail(
+              'expected ' + chai.datetime.formatTime(this.d1) + ' to be around ' + chai.datetime.formatTime(this.d2) + ' +/- 500 ms'
+            );
+          });
+
+          describe('when negated', function() {
+            it('passes', function() {
+              this.d1.should.not.be.aroundTime(this.d2, 500);
+            });
+          });
+        });
+      });
+
+      describe('when first time is after second', function() {
+        describe('and delta is exact difference between two times', function() {
+          beforeEach(function() {
+            this.d1 = new Date(2013, 4, 30, 16, 5, 1);
+            this.d2 = new Date(2013, 4, 30, 16, 5, 0);
+          });
+
+          it('passes', function() {
+            this.d1.should.be.aroundTime(this.d2, 1000);
+          });
+
+          describe('when negated', function() {
+            it('fails', function() {
+              var test = this;
+
+              (function() {
+                test.d1.should.not.be.aroundTime(test.d2, 1000)
+              }).should.fail(
+                'expected ' + chai.datetime.formatTime(this.d1) + ' not to be around ' + chai.datetime.formatTime(this.d2) + ' +/- 1000 ms'
+              );
+            });
+          });
+        });
+
+        describe('and delta is bigger than two times difference', function() {
+          beforeEach(function() {
+            this.d1 = new Date(2013, 4, 30, 16, 5, 1);
+            this.d2 = new Date(2013, 4, 30, 16, 5, 0);
+          });
+
+          it('passes', function() {
+            this.d1.should.be.aroundTime(this.d2, 2000);
+          });
+
+          describe('when negated', function() {
+            it('fails', function() {
+              var test = this;
+
+              (function() {
+                test.d1.should.not.be.aroundTime(test.d2, 2000)
+              }).should.fail(
+                'expected ' + chai.datetime.formatTime(this.d1) + ' not to be around ' + chai.datetime.formatTime(this.d2) + ' +/- 2000 ms'
+              );
+            });
+          });
+        });
+
+        describe('and delta is smaller than two times difference', function() {
+          beforeEach(function() {
+            this.d1 = new Date(2013, 4, 30, 16, 5, 1);
+            this.d2 = new Date(2013, 4, 30, 16, 5, 0);
+          });
+
+          it('fails', function() {
+            var test = this;
+
+            (function() {
+              test.d1.should.be.aroundTime(test.d2, 500)
+            }).should.fail(
+              'expected ' + chai.datetime.formatTime(this.d1) + ' to be around ' + chai.datetime.formatTime(this.d2) + ' +/- 500 ms'
+            );
+          });
+
+          describe('when negated', function() {
+            it('passes', function() {
+              this.d1.should.not.be.aroundTime(this.d2, 500);
+            });
+          });
+        });
+      });
+    });
+
     describe('formatTime', function() {
       describe('printing the date at the start', function() {
         it('prints the date at the beginning of the string', function() {


### PR DESCRIPTION
implementation of another assertion - `aroundTime`.
```js
expect(t1).to.be.aroundTime(t2, 1000)
```
passes when t1 is in t2 +/- 1000 milliseconds.

i often find myself implementing this using `timeBefore` and `timeAfter` when i test some kind of auto generated timestamps for example.