### PR TITLE
Added the dateWithin and timeWithin methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ portion of the Date object.
 * equalTime
 * beforeTime
 * afterTime
+* withinTime
 * equalDate
 * beforeDate
 * afterDate
+* withinDate
 
 All assertions are defined for both the BDD and TDD syntaxes.
 

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -92,6 +92,10 @@
     return actual.getTime() > expected.getTime();
   };
 
+  chai.datetime.withinTime = function(actual, expectedFrom, expectedTo) {
+    return actual.getTime() >= expectedFrom.getTime() && actual.getTime() <= expectedTo.getTime();
+  };
+
   chai.Assertion.addChainableMethod('equalTime', function(expected) {
     var actual = this._obj;
 
@@ -162,6 +166,16 @@
       chai.datetime.afterTime(actual, expected),
       'expected ' + chai.datetime.formatTime(actual) + ' to be after ' + chai.datetime.formatTime(expected),
       'expected ' + chai.datetime.formatTime(actual) + ' not to be after ' + chai.datetime.formatTime(expected)
+    );
+  });
+
+  chai.Assertion.addChainableMethod('withinTime', function(expectedFrom, expectedTo) {
+    var actual = this._obj;
+
+    this.assert(
+      chai.datetime.withinTime(actual, expectedFrom, expectedTo),
+      'expected ' + chai.datetime.formatTime(actual) + ' to be within ' + chai.datetime.formatTime(expectedFrom) + ' and ' + chai.datetime.formatTime(expectedTo),
+      'expected ' + chai.datetime.formatTime(actual) + ' not to be within ' + chai.datetime.formatTime(expectedFrom) + ' and ' + chai.datetime.formatTime(expectedTo)
     );
   });
 

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -80,6 +80,10 @@
     return chai.datetime.afterTime(dateWithoutTime(actual), dateWithoutTime(expected));
   };
 
+  chai.datetime.withinDate = function(actual, expectedFrom, expectedTo) {
+    return actual.getTime() >= expectedFrom.getTime() && actual.getTime() <= expectedTo.getTime();
+  };
+
   chai.datetime.beforeTime = function(actual, expected) {
     return actual.getTime() < expected.getTime();
   };
@@ -128,6 +132,16 @@
       chai.datetime.afterDate(actual, expected),
       'expected ' + chai.datetime.formatDate(actual) + ' to be after ' + chai.datetime.formatDate(expected),
       'expected ' + chai.datetime.formatDate(actual) + ' not to be after ' + chai.datetime.formatDate(expected)
+    );
+  });
+
+  chai.Assertion.addChainableMethod('withinDate', function(expectedFrom, expectedTo) {
+    var actual = this._obj;
+
+    this.assert(
+      chai.datetime.withinDate(actual, expectedFrom, expectedTo),
+      'expected ' + chai.datetime.formatDate(actual) + ' to be within ' + chai.datetime.formatDate(expectedFrom) + ' and ' + chai.datetime.formatDate(expectedTo),
+      'expected ' + chai.datetime.formatDate(actual) + ' not to be within ' + chai.datetime.formatDate(expectedFrom) + ' and ' + chai.datetime.formatDate(expectedTo)
     );
   });
 

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -210,6 +210,14 @@
     new chai.Assertion(val, msg).not.to.be.afterDate(exp);
   };
 
+  assert.withinDate = function(val, expFrom, expTo, msg) {
+    new chai.Assertion(val, msg).to.be.withinDate(expFrom, expTo);
+  };
+
+  assert.notWithinDate = function(val, expFrom, expTo, msg) {
+    new chai.Assertion(val, msg).not.to.be.withinDate(expFrom, expTo);
+  };
+
   assert.equalTime = function(val, exp, msg) {
     new chai.Assertion(val, msg).to.be.equalTime(exp);
   };
@@ -234,4 +242,11 @@
     new chai.Assertion(val, msg).to.not.be.afterTime(exp);
   };
 
+  assert.withinTime = function(val, expFrom, expTo, msg) {
+    new chai.Assertion(val, msg).to.be.withinTime(expFrom, expTo);
+  };
+
+  assert.notWithinTime = function(val, expFrom, expTo, msg) {
+    new chai.Assertion(val, msg).not.to.be.withinTime(expFrom, expTo);
+  };
 }));

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -81,7 +81,11 @@
   };
 
   chai.datetime.withinDate = function(actual, expectedFrom, expectedTo) {
-    return actual.getTime() >= expectedFrom.getTime() && actual.getTime() <= expectedTo.getTime();
+    return chai.datetime.withinTime(
+      dateWithoutTime(actual),
+      dateWithoutTime(expectedFrom),
+      dateWithoutTime(expectedTo)
+    );
   };
 
   chai.datetime.beforeTime = function(actual, expected) {

--- a/test/test.js
+++ b/test/test.js
@@ -391,6 +391,80 @@
       })
     });
 
+    describe('withinDate', function() {
+      describe('when given a date between two dates', function() {
+        beforeEach(function() {
+          this.d1 = new Date(2013, 4, 30);
+          this.d2 = new Date(2013, 4, 29);
+          this.d3 = new Date(2013, 4, 31);
+        });
+
+        it('passes', function() {
+          this.d1.should.be.withinDate(this.d2, this.d3);
+        });
+
+        describe('when negated', function() {
+          it('fails', function() {
+            var test = this;
+
+            (function() {
+              test.d1.should.not.be.withinDate(test.d2, test.d3);
+            }).should.fail(
+              'expected Thu May 30 2013 not to be within Wed May 29 2013 and Fri May 31 2013'
+            );
+          });
+        });
+      });
+
+      describe('when given a date that is not between two dates', function() {
+        beforeEach(function() {
+          this.d1 = new Date(2013, 4, 28);
+          this.d2 = new Date(2013, 4, 29);
+          this.d3 = new Date(2013, 4, 31);
+        });
+
+        it('fails', function() {
+          var test = this;
+
+          (function() {
+            test.d1.should.be.withinDate(test.d2, test.d3);
+          }).should.fail(
+            'expected Tue May 28 2013 to be within Wed May 29 2013 and Fri May 31 2013'
+          );
+        });
+
+        describe('when negated', function() {
+          it('passes', function() {
+            this.d1.should.not.be.withinDate(this.d2, this.d3);
+          });
+        });
+      });
+
+      describe('when given three identical dates', function() {
+        beforeEach(function() {
+          this.d1 = new Date(2013, 4, 30);
+          this.d2 = new Date(2013, 4, 30);
+          this.d3 = new Date(2013, 4, 30);
+        });
+
+        it('passes', function() {
+          this.d1.should.be.withinDate(this.d2, this.d3);
+        });
+
+        describe('when negated', function() {
+          it('fails', function() {
+            var test = this;
+
+            (function() {
+              test.d1.should.not.be.withinDate(test.d2, test.d3);
+            }).should.fail(
+              'expected Thu May 30 2013 not to be within Thu May 30 2013 and Thu May 30 2013'
+            );
+          });
+        });
+      });
+    });
+
     describe('beforeTime', function() {
       describe('when comparing two different times', function() {
         beforeEach(function() {

--- a/test/test.js
+++ b/test/test.js
@@ -561,6 +561,80 @@
       });
     });
 
+    describe('withinTime', function() {
+      describe('when given a time between two times', function() {
+        beforeEach(function() {
+          this.d1 = new Date(2013, 4, 30, 16, 5, 1);
+          this.d2 = new Date(2013, 4, 30, 16, 5, 0);
+          this.d3 = new Date(2013, 4, 30, 16, 5, 2);
+        });
+
+        it('passes', function() {
+          this.d1.should.be.withinTime(this.d2, this.d3);
+        });
+
+        describe('when negated', function() {
+          it('fails', function() {
+            var test = this;
+
+            (function() {
+              test.d1.should.not.be.withinTime(test.d2, test.d3);
+            }).should.fail(
+              'expected Thu May 30 2013 16:05:01.000 (+01:00) not to be within Thu May 30 2013 16:05:00.000 (+01:00) and Thu May 30 2013 16:05:02.000 (+01:00)'
+            );
+          });
+        });
+      });
+
+      describe('when given a time that is not between two times', function() {
+        beforeEach(function() {
+          this.d1 = new Date(2013, 4, 30, 16, 5, 0);
+          this.d2 = new Date(2013, 4, 30, 16, 5, 1);
+          this.d3 = new Date(2013, 4, 30, 16, 5, 2);
+        });
+
+        it('fails', function() {
+          var test = this;
+
+          (function() {
+            test.d1.should.be.withinTime(test.d2, test.d3);
+          }).should.fail(
+            'expected Thu May 30 2013 16:05:00.000 (+01:00) to be within Thu May 30 2013 16:05:01.000 (+01:00) and Thu May 30 2013 16:05:02.000 (+01:00)'
+          );
+        });
+
+        describe('when negated', function() {
+          it('passes', function() {
+            this.d1.should.not.be.withinTime(this.d2, this.d3);
+          });
+        });
+      });
+
+      describe('when given three identical times', function() {
+        beforeEach(function() {
+          this.d1 = new Date(2013, 4, 30, 16, 5, 1);
+          this.d2 = new Date(2013, 4, 30, 16, 5, 1);
+          this.d3 = new Date(2013, 4, 30, 16, 5, 1);
+        });
+
+        it('passes', function() {
+          this.d1.should.be.withinTime(this.d2, this.d3);
+        });
+
+        describe('when negated', function() {
+          it('fails', function() {
+            var test = this;
+
+            (function() {
+              test.d1.should.not.be.withinTime(test.d2, test.d3);
+            }).should.fail(
+              'expected Thu May 30 2013 16:05:01.000 (+01:00) not to be within Thu May 30 2013 16:05:01.000 (+01:00) and Thu May 30 2013 16:05:01.000 (+01:00)'
+            );
+          });
+        });
+      });
+    });
+
     describe('formatTime', function() {
       describe('printing the date at the start', function() {
         it('prints the date at the beginning of the string', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -580,7 +580,7 @@
             (function() {
               test.d1.should.not.be.withinTime(test.d2, test.d3);
             }).should.fail(
-              'expected Thu May 30 2013 16:05:01.000 (+01:00) not to be within Thu May 30 2013 16:05:00.000 (+01:00) and Thu May 30 2013 16:05:02.000 (+01:00)'
+              'expected ' + chai.datetime.formatTime(test.d1) + ' not to be within ' + chai.datetime.formatTime(test.d2) + ' and ' + chai.datetime.formatTime(test.d3)
             );
           });
         });
@@ -599,7 +599,7 @@
           (function() {
             test.d1.should.be.withinTime(test.d2, test.d3);
           }).should.fail(
-            'expected Thu May 30 2013 16:05:00.000 (+01:00) to be within Thu May 30 2013 16:05:01.000 (+01:00) and Thu May 30 2013 16:05:02.000 (+01:00)'
+            'expected ' + chai.datetime.formatTime(test.d1) + ' to be within ' + chai.datetime.formatTime(test.d2) + ' and ' + chai.datetime.formatTime(test.d3)
           );
         });
 
@@ -628,7 +628,7 @@
             (function() {
               test.d1.should.not.be.withinTime(test.d2, test.d3);
             }).should.fail(
-              'expected Thu May 30 2013 16:05:01.000 (+01:00) not to be within Thu May 30 2013 16:05:01.000 (+01:00) and Thu May 30 2013 16:05:01.000 (+01:00)'
+              'expected ' + chai.datetime.formatTime(test.d1) + ' not to be within ' + chai.datetime.formatTime(test.d2) + ' and ' + chai.datetime.formatTime(test.d3)
             );
           });
         });

--- a/test/test.js
+++ b/test/test.js
@@ -742,6 +742,14 @@
         assert.notAfterDate(this.subject, new Date(2013, 4, 30));
       });
 
+      it('.withinDate', function() {
+        assert.withinDate(this.subject, new Date(2013, 4, 29), new Date(2013, 4, 31));
+      });
+
+      it('.notWithinDate', function() {
+        assert.notWithinDate(this.subject, new Date(2013, 4, 31), new Date(2013, 5, 0));
+      });
+
       it('.equalTime', function() {
         assert.equalTime(this.subject, new Date(2013, 4, 30, 16, 5));
       });
@@ -766,6 +774,13 @@
         assert.notAfterTime(this.subject, new Date(2013, 4, 30, 16, 6));
       });
 
+      it('.withinTime', function() {
+        assert.withinTime(this.subject, new Date(2013, 4, 30, 16, 4), new Date(2013, 4, 30, 16, 6));
+      });
+
+      it('.notWithinTime', function() {
+        assert.notWithinTime(this.subject, new Date(2013, 4, 30, 16, 6), new Date(2013, 4, 30, 16, 7));
+      });
     });
   });
 }));


### PR DESCRIPTION
I was hoping I would be able to use the `expect(date).to.be.within(startDate, endDate)` syntax to make sure my date was in a specific range, but as you mentioned in the readme, the error messages are not that great.

I usually like to make sure my date is within a specific range, as I am writing tests for a faker library ([fakergem](https://github.com/mrstebo/fakergem)). So I needed needed to extend the current functionality.

Hope this helps everyone :+1: 


Great project! Was very easy to add in these extra features!