### PR TITLE
Implement chai closeToTime assertion (time close with a 1-second precision)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ assertion that specifies date in the name only compares the date
 portion of the Date object.
 
 * equalTime
+* closeToTime (with a 1 second margin)
 * beforeTime
 * afterTime
 * withinTime

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ assertion that specifies date in the name only compares the date
 portion of the Date object.
 
 * equalTime
-* closeToTime (with a configurable delta, 1 second by default)
+* closeToTime (with a configurable delta in seconds)
 * beforeTime
 * afterTime
 * withinTime

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ assertion that specifies date in the name only compares the date
 portion of the Date object.
 
 * equalTime
-* closeToTime (with a configurable margin, 1 second by default)
+* closeToTime (with a configurable delta, 1 second by default)
 * beforeTime
 * afterTime
 * withinTime

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ assertion that specifies date in the name only compares the date
 portion of the Date object.
 
 * equalTime
-* closeToTime (with a 1 second margin)
+* closeToTime (with a configurable margin, 1 second by default)
 * beforeTime
 * afterTime
 * withinTime

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -64,9 +64,9 @@
     return actual.getTime() == expected.getTime();
   };
 
-  chai.datetime.closeToTime = function(actual, expected, marginInSeconds) {
-    marginInSeconds = marginInSeconds || 1
-    return Math.abs(actual.getTime() - expected.getTime()) < marginInSeconds * 1000;
+  chai.datetime.closeToTime = function(actual, expected, deltaInSeconds) {
+    deltaInSeconds = deltaInSeconds || 1
+    return Math.abs(actual.getTime() - expected.getTime()) < deltaInSeconds * 1000;
   };
 
   chai.datetime.equalDate = function(actual, expected) {
@@ -117,14 +117,14 @@
     );
   });
 
-  chai.Assertion.addChainableMethod('closeToTime', function(expected, marginInSeconds) {
+  chai.Assertion.addChainableMethod('closeToTime', function(expected, deltaInSeconds) {
     var actual = this._obj;
-    marginInSeconds = marginInSeconds || 1
+    deltaInSeconds = deltaInSeconds || 1
 
     return this.assert(
-      chai.datetime.closeToTime(expected, actual, marginInSeconds),
-      'expected ' + this._obj + ' to be within ' + marginInSeconds + 's of ' + expected,
-      'expected ' + this._obj + ' to not be within ' + marginInSeconds + 's of ' + expected,
+      chai.datetime.closeToTime(expected, actual, deltaInSeconds),
+      'expected ' + this._obj + ' to be within ' + deltaInSeconds + 's of ' + expected,
+      'expected ' + this._obj + ' to not be within ' + deltaInSeconds + 's of ' + expected,
       expected.toString(),
       actual.toString()
     );

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -64,9 +64,10 @@
     return actual.getTime() == expected.getTime();
   };
 
-  chai.datetime.closeToTime = function(actual, expected) {
-    const ONE_SECOND_IN_MILLISECONDS = 1 * 1000;
-    return Math.abs(actual.getTime() - expected.getTime()) < ONE_SECOND_IN_MILLISECONDS;
+  chai.datetime.closeToTime = function(actual, expected, marginInSeconds) {
+    const ONE_SECOND_IN_MILLISECONDS = 1;
+    marginInSeconds = marginInSeconds || ONE_SECOND
+    return Math.abs(actual.getTime() - expected.getTime()) < marginInSeconds * 1000;
   };
 
   chai.datetime.equalDate = function(actual, expected) {
@@ -117,11 +118,11 @@
     );
   });
 
-  chai.Assertion.addChainableMethod('closeToTime', function(expected) {
+  chai.Assertion.addChainableMethod('closeToTime', function(expected, marginInSeconds) {
     var actual = this._obj;
 
     return this.assert(
-      chai.datetime.closeToTime(expected, actual),
+      chai.datetime.closeToTime(expected, actual, marginInSeconds),
       'expected ' + this._obj + ' to be close to ' + expected,
       'expected ' + this._obj + ' to not be close to ' + expected,
       expected.toString(),

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -65,8 +65,7 @@
   };
 
   chai.datetime.closeToTime = function(actual, expected, marginInSeconds) {
-    const ONE_SECOND_IN_MILLISECONDS = 1;
-    marginInSeconds = marginInSeconds || ONE_SECOND
+    marginInSeconds = marginInSeconds || 1
     return Math.abs(actual.getTime() - expected.getTime()) < marginInSeconds * 1000;
   };
 
@@ -120,11 +119,12 @@
 
   chai.Assertion.addChainableMethod('closeToTime', function(expected, marginInSeconds) {
     var actual = this._obj;
+    marginInSeconds = marginInSeconds || 1
 
     return this.assert(
       chai.datetime.closeToTime(expected, actual, marginInSeconds),
-      'expected ' + this._obj + ' to be close to ' + expected,
-      'expected ' + this._obj + ' to not be close to ' + expected,
+      'expected ' + this._obj + ' to be within ' + marginInSeconds + 's of ' + expected,
+      'expected ' + this._obj + ' to not be within ' + marginInSeconds + 's of ' + expected,
       expected.toString(),
       actual.toString()
     );

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -64,6 +64,11 @@
     return actual.getTime() == expected.getTime();
   };
 
+  chai.datetime.closeToTime = function(actual, expected) {
+    const ONE_SECOND_IN_MILLISECONDS = 1 * 1000;
+    return Math.abs(actual.getTime() - expected.getTime()) < ONE_SECOND_IN_MILLISECONDS;
+  };
+
   chai.datetime.equalDate = function(actual, expected) {
     return actual.toDateString() === expected.toDateString();
   };
@@ -107,6 +112,18 @@
       chai.datetime.equalTime(expected, actual),
       'expected ' + this._obj + ' to equal ' + expected,
       'expected ' + this._obj + ' to not equal ' + expected,
+      expected.toString(),
+      actual.toString()
+    );
+  });
+
+  chai.Assertion.addChainableMethod('closeToTime', function(expected) {
+    var actual = this._obj;
+
+    return this.assert(
+      chai.datetime.closeToTime(expected, actual),
+      'expected ' + this._obj + ' to be close to ' + expected,
+      'expected ' + this._obj + ' to not be close to ' + expected,
       expected.toString(),
       actual.toString()
     );

--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -65,7 +65,6 @@
   };
 
   chai.datetime.closeToTime = function(actual, expected, deltaInSeconds) {
-    deltaInSeconds = deltaInSeconds || 1
     return Math.abs(actual.getTime() - expected.getTime()) < deltaInSeconds * 1000;
   };
 
@@ -119,7 +118,10 @@
 
   chai.Assertion.addChainableMethod('closeToTime', function(expected, deltaInSeconds) {
     var actual = this._obj;
-    deltaInSeconds = deltaInSeconds || 1
+
+    if((!deltaInSeconds && deltaInSeconds !== 0) || typeof deltaInSeconds !== 'number') {
+      throw new chai.AssertionError('second argument of closeToTime, \'deltaInSeconds\', must be a number')
+    }
 
     return this.assert(
       chai.datetime.closeToTime(expected, actual, deltaInSeconds),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,16 @@
 {
   "name": "chai-datetime",
   "version": "1.5.0",
-  "keywords": ["chai", "chai-plugin", "objects", "date", "time", "browser", "testing", "jasmine"],
+  "keywords": [
+    "chai",
+    "chai-plugin",
+    "objects",
+    "date",
+    "time",
+    "browser",
+    "testing",
+    "jasmine"
+  ],
   "description": "date / time comparison matchers for chai",
   "main": "chai-datetime.js",
   "scripts": {
@@ -21,7 +30,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "mocha": "~1.6.0",
+    "mocha": "^7.1.1",
     "nodemon": "~0.6.23"
   },
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -203,6 +203,51 @@
 
       });
 
+      describe('closeToTime', function() {
+        beforeEach(function() {
+          this.subject = new Date(2013, 4, 30, 16, 5, 16, 323);
+          this.closeTo = new Date(2013, 4, 30, 16, 5, 16, 581);
+          this.different = new Date(2013, 4, 30, 16, 6);
+        });
+
+        describe('when given two date objects with the same values', function() {
+          it('passes', function() {
+            this.subject.should.be.closeToTime(this.closeTo);
+          });
+
+          describe('when negated', function() {
+            it('fails', function() {
+              var test = this;
+
+              (function() {
+                test.subject.should.not.be.closeToTime(test.closeTo);
+              }).should.fail(
+                'expected ' + test.subject + ' to not be close to ' + test.closeTo
+              );
+            });
+          });
+        });
+
+        describe('when given two date objects with different values', function() {
+          it('fails', function() {
+            var test = this;
+
+            (function() {
+              test.subject.should.be.closeToTime(test.different);
+            }).should.fail(
+              'expected ' + test.subject + ' to be close to ' + test.different
+            );
+          });
+
+          describe('when negated', function() {
+            it('passes', function() {
+              this.subject.should.not.be.closeToTime(this.different);
+            });
+          });
+        });
+
+      });
+
       describe('equalDate', function() {
         beforeEach(function() {
           this.subject = new Date(2013, 4, 30, 16, 5);

--- a/test/test.js
+++ b/test/test.js
@@ -206,13 +206,14 @@
       describe('closeToTime', function() {
         beforeEach(function() {
           this.subject = new Date(2013, 4, 30, 16, 5, 16, 323);
-          this.closeTo = new Date(2013, 4, 30, 16, 5, 16, 581);
+          this.subjetPlus200Milliseconds = new Date(2013, 4, 30, 16, 5, 16, 523);
+          this.subjetPlus3seconds = new Date(2013, 4, 30, 16, 5, 19, 323);
           this.different = new Date(2013, 4, 30, 16, 6);
         });
 
-        describe('when given two date objects with the same values', function() {
+        describe('when given two date objects within default margin', function() {
           it('passes', function() {
-            this.subject.should.be.closeToTime(this.closeTo);
+            this.subject.should.be.closeToTime(this.subjetPlus200Milliseconds);
           });
 
           describe('when negated', function() {
@@ -220,9 +221,29 @@
               var test = this;
 
               (function() {
-                test.subject.should.not.be.closeToTime(test.closeTo);
+                test.subject.should.not.be.closeToTime(test.subjetPlus200Milliseconds);
               }).should.fail(
-                'expected ' + test.subject + ' to not be close to ' + test.closeTo
+                'expected ' + test.subject + ' to not be close to ' + test.subjetPlus200Milliseconds
+              );
+            });
+          });
+        });
+
+        describe('when given two date objects within the configured margin', function() {
+          const marginInSeconds = 5
+
+          it('passes', function() {
+            this.subject.should.be.closeToTime(this.subjetPlus3seconds, marginInSeconds);
+          });
+
+          describe('when negated', function() {
+            it('fails', function() {
+              var test = this;
+
+              (function() {
+                test.subject.should.not.be.closeToTime(test.subjetPlus3seconds, marginInSeconds);
+              }).should.fail(
+                'expected ' + test.subject + ' to not be close to ' + test.subjetPlus3seconds
               );
             });
           });

--- a/test/test.js
+++ b/test/test.js
@@ -211,9 +211,15 @@
           this.different = new Date(2013, 4, 30, 18, 6);
         });
 
-        describe('when given two date objects within default delta', function() {
-          it('passes', function() {
-            this.subject.should.be.closeToTime(this.subjetPlus200Milliseconds);
+        describe('when given two date objects but no delta', function() {
+          it.only('fails', function() {
+            var test = this;
+
+            (function() {
+              test.subject.should.be.closeToTime(this.subjetPlus200Milliseconds);
+            }).should.fail(
+              'second argument of closeToTime, \'deltaInSeconds\', must be a number'
+            );
           });
 
           describe('when negated', function() {
@@ -223,7 +229,7 @@
               (function() {
                 test.subject.should.not.be.closeToTime(test.subjetPlus200Milliseconds);
               }).should.fail(
-                'expected ' + test.subject + ' to not be within 1s of ' + test.subjetPlus200Milliseconds
+                'second argument of closeToTime, \'deltaInSeconds\', must be a number'
               );
             });
           });
@@ -245,24 +251,6 @@
               }).should.fail(
                 'expected ' + test.subject + ' to not be within 5s of ' + test.subjetPlus3seconds
               );
-            });
-          });
-        });
-
-        describe('when given two date objects with values not within default delta', function() {
-          it('fails', function() {
-            var test = this;
-
-            (function() {
-              test.subject.should.be.closeToTime(test.different);
-            }).should.fail(
-              'expected ' + test.subject + ' to be within 1s of ' + test.different
-            );
-          });
-
-          describe('when negated', function() {
-            it('passes', function() {
-              this.subject.should.not.be.closeToTime(this.different);
             });
           });
         });

--- a/test/test.js
+++ b/test/test.js
@@ -208,7 +208,7 @@
           this.subject = new Date(2013, 4, 30, 16, 5, 16, 323);
           this.subjetPlus200Milliseconds = new Date(2013, 4, 30, 16, 5, 16, 523);
           this.subjetPlus3seconds = new Date(2013, 4, 30, 16, 5, 19, 323);
-          this.different = new Date(2013, 4, 30, 16, 6);
+          this.different = new Date(2013, 4, 30, 18, 6);
         });
 
         describe('when given two date objects within default margin', function() {
@@ -223,7 +223,7 @@
               (function() {
                 test.subject.should.not.be.closeToTime(test.subjetPlus200Milliseconds);
               }).should.fail(
-                'expected ' + test.subject + ' to not be close to ' + test.subjetPlus200Milliseconds
+                'expected ' + test.subject + ' to not be within 1s of ' + test.subjetPlus200Milliseconds
               );
             });
           });
@@ -243,26 +243,45 @@
               (function() {
                 test.subject.should.not.be.closeToTime(test.subjetPlus3seconds, marginInSeconds);
               }).should.fail(
-                'expected ' + test.subject + ' to not be close to ' + test.subjetPlus3seconds
+                'expected ' + test.subject + ' to not be within 5s of ' + test.subjetPlus3seconds
               );
             });
           });
         });
 
-        describe('when given two date objects with different values', function() {
+        describe('when given two date objects with values not within default margin', function() {
           it('fails', function() {
             var test = this;
 
             (function() {
               test.subject.should.be.closeToTime(test.different);
             }).should.fail(
-              'expected ' + test.subject + ' to be close to ' + test.different
+              'expected ' + test.subject + ' to be within 1s of ' + test.different
             );
           });
 
           describe('when negated', function() {
             it('passes', function() {
               this.subject.should.not.be.closeToTime(this.different);
+            });
+          });
+        });
+
+        describe('when given two date objects with values not within configured margin', function() {
+          const marginInSeconds = 50
+          it('fails', function() {
+            var test = this;
+
+            (function() {
+              test.subject.should.be.closeToTime(test.different, marginInSeconds);
+            }).should.fail(
+              'expected ' + test.subject + ' to be within 50s of ' + test.different
+            );
+          });
+
+          describe('when negated', function() {
+            it('passes', function() {
+              this.subject.should.not.be.closeToTime(this.different, marginInSeconds);
             });
           });
         });

--- a/test/test.js
+++ b/test/test.js
@@ -211,7 +211,7 @@
           this.different = new Date(2013, 4, 30, 18, 6);
         });
 
-        describe('when given two date objects within default margin', function() {
+        describe('when given two date objects within default delta', function() {
           it('passes', function() {
             this.subject.should.be.closeToTime(this.subjetPlus200Milliseconds);
           });
@@ -229,11 +229,11 @@
           });
         });
 
-        describe('when given two date objects within the configured margin', function() {
-          const marginInSeconds = 5
+        describe('when given two date objects within the configured delta', function() {
+          const deltaInSeconds = 5
 
           it('passes', function() {
-            this.subject.should.be.closeToTime(this.subjetPlus3seconds, marginInSeconds);
+            this.subject.should.be.closeToTime(this.subjetPlus3seconds, deltaInSeconds);
           });
 
           describe('when negated', function() {
@@ -241,7 +241,7 @@
               var test = this;
 
               (function() {
-                test.subject.should.not.be.closeToTime(test.subjetPlus3seconds, marginInSeconds);
+                test.subject.should.not.be.closeToTime(test.subjetPlus3seconds, deltaInSeconds);
               }).should.fail(
                 'expected ' + test.subject + ' to not be within 5s of ' + test.subjetPlus3seconds
               );
@@ -249,7 +249,7 @@
           });
         });
 
-        describe('when given two date objects with values not within default margin', function() {
+        describe('when given two date objects with values not within default delta', function() {
           it('fails', function() {
             var test = this;
 
@@ -267,13 +267,13 @@
           });
         });
 
-        describe('when given two date objects with values not within configured margin', function() {
-          const marginInSeconds = 50
+        describe('when given two date objects with values not within configured delta', function() {
+          const deltaInSeconds = 50
           it('fails', function() {
             var test = this;
 
             (function() {
-              test.subject.should.be.closeToTime(test.different, marginInSeconds);
+              test.subject.should.be.closeToTime(test.different, deltaInSeconds);
             }).should.fail(
               'expected ' + test.subject + ' to be within 50s of ' + test.different
             );
@@ -281,7 +281,7 @@
 
           describe('when negated', function() {
             it('passes', function() {
-              this.subject.should.not.be.closeToTime(this.different, marginInSeconds);
+              this.subject.should.not.be.closeToTime(this.different, deltaInSeconds);
             });
           });
         });


### PR DESCRIPTION
Add a closeToTime chai assertion that checks that two times are less than 1 second apart
This is useful when you call a function that calls `new Date()`, and comparing later to a new call to `new Date()` with a better precision thatn just using `equalDate`

