### PR TITLE
Update node versions tested on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
+  - 10
+  - 12
+  - lts/*
+  - node


### PR DESCRIPTION
Make this list match what is current on the main Chai repo. I've removed support for Node 8, which is noted not to be supported after Dec 31, 2019.

This was causing #36 not to pass.