### PR TITLE
Included closeToTime in asserts and tdd aliases

### DIFF
--- a/chai-datetime.js
+++ b/chai-datetime.js
@@ -446,6 +446,10 @@
     new chai.Assertion(val, msg).not.to.be.afterOrEqualTime(exp);
   };
 
+  assert.closeToTime = function (val, exp, delta, msg) {
+    new chai.Assertion(val, msg).to.be.closeToTime(exp, delta);
+  };
+
   assert.withinTime = function (val, expFrom, expTo, msg) {
     new chai.Assertion(val, msg).to.be.withinTime(expFrom, expTo);
   };

--- a/test/test.js
+++ b/test/test.js
@@ -1181,6 +1181,10 @@
         assert.notAfterOrEqualTime(this.subject, new Date(2013, 4, 30, 16, 6));
       });
 
+      it(".closeToTime", function () {
+        assert.closeToTime(this.subject, new Date(2013, 4, 30, 16, 6), 90);
+      });
+
       it(".withinTime", function () {
         assert.withinTime(
           this.subject,


### PR DESCRIPTION
The function closeToTime was not added to asserts nor tdd tests. When invoked in Node.js via Chai it returned the error "Uncaught TypeError: assert.closeToTime is not a function".